### PR TITLE
Add basic lecturer management MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,19 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# DHBW Vorlesungsplanung
 
-## Getting Started
+Dieses Projekt stellt ein kleines MVP zur Verwaltung von Dozierenden dar. Die Anwendung basiert auf Next.js und speichert Daten im Browser `localStorage`.
 
-First, run the development server:
+## Entwicklung starten
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Die Anwendung läuft anschließend unter http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Funktionen
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- Liste der Dozierenden unter `/dozierende`
+- Hinzufügen neuer Dozent\*innen über ein Formular
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Die Daten werden lokal im Browser gespeichert und können nach einem Reload wieder aufgerufen werden.

--- a/app/dozierende/neu/page.tsx
+++ b/app/dozierende/neu/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { lecturerService } from '@/lib/lecturerService';
+import { Lecturer } from '@/lib/types';
+import { v4 as uuidv4 } from 'uuid';
+
+export default function NewLecturerPage() {
+  const router = useRouter();
+  const [form, setForm] = useState<Omit<Lecturer, 'id' | 'createdAt' | 'updatedAt'>>({
+    firstname: '',
+    lastname: '',
+    title: '',
+    email: '',
+    type: 'internal',
+    yearlyHoursLimit: 240,
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newLecturer: Lecturer = {
+      ...form,
+      yearlyHoursLimit: form.type === 'external' ? Number(form.yearlyHoursLimit) : undefined,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await lecturerService.create(newLecturer);
+    router.push('/dozierende');
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Neue*r Dozent*in</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Vorname</label>
+          <input name="firstname" className="border w-full p-2" value={form.firstname} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Nachname</label>
+          <input name="lastname" className="border w-full p-2" value={form.lastname} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Titel</label>
+          <input name="title" className="border w-full p-2" value={form.title} onChange={handleChange} />
+        </div>
+        <div>
+          <label className="block mb-1">E-Mail</label>
+          <input type="email" name="email" className="border w-full p-2" value={form.email} onChange={handleChange} />
+        </div>
+        <div>
+          <label className="block mb-1">Typ</label>
+          <select name="type" className="border w-full p-2" value={form.type} onChange={handleChange}>
+            <option value="internal">Intern</option>
+            <option value="external">Extern</option>
+          </select>
+        </div>
+        {form.type === 'external' && (
+          <div>
+            <label className="block mb-1">Jahresstundenlimit</label>
+            <input
+              type="number"
+              name="yearlyHoursLimit"
+              className="border w-full p-2"
+              value={form.yearlyHoursLimit}
+              onChange={handleChange}
+            />
+          </div>
+        )}
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">
+          Speichern
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/dozierende/page.tsx
+++ b/app/dozierende/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { lecturerService } from '@/lib/lecturerService';
+import { Lecturer } from '@/lib/types';
+
+export default function DozierendePage() {
+  const [lecturers, setLecturers] = useState<Lecturer[]>([]);
+
+  useEffect(() => {
+    lecturerService.getAll().then(setLecturers);
+  }, []);
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Dozierende</h1>
+        <Link href="/dozierende/neu" className="text-blue-600 hover:underline">
+          + Hinzufügen
+        </Link>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-2 py-1 text-left">Name</th>
+            <th className="px-2 py-1 text-left">Typ</th>
+            <th className="px-2 py-1 text-left">E-Mail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lecturers.map((l) => (
+            <tr key={l.id} className="border-t">
+              <td className="px-2 py-1">
+                {l.title ? `${l.title} ` : ''}{l.firstname} {l.lastname}
+              </td>
+              <td className="px-2 py-1">{l.type}</td>
+              <td className="px-2 py-1">{l.email}</td>
+            </tr>
+          ))}
+          {lecturers.length === 0 && (
+            <tr>
+              <td colSpan={3} className="p-4 text-center text-sm text-muted-foreground">
+                Keine Dozierenden vorhanden
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/dataService.ts
+++ b/lib/dataService.ts
@@ -1,0 +1,36 @@
+export abstract class DataService<T extends { id: string }> {
+  protected abstract storageKey: string;
+
+  async getAll(): Promise<T[]> {
+    if (typeof window === 'undefined') return [];
+    const data = localStorage.getItem(this.storageKey);
+    return data ? (JSON.parse(data) as T[]) : [];
+  }
+
+  async getById(id: string): Promise<T | null> {
+    const items = await this.getAll();
+    return items.find((i) => i.id === id) || null;
+  }
+
+  async create(item: T): Promise<T> {
+    const items = await this.getAll();
+    items.push(item);
+    localStorage.setItem(this.storageKey, JSON.stringify(items));
+    return item;
+  }
+
+  async update(id: string, item: Partial<T>): Promise<T> {
+    const items = await this.getAll();
+    const index = items.findIndex((i) => i.id === id);
+    if (index === -1) throw new Error('Item not found');
+    items[index] = { ...items[index], ...item };
+    localStorage.setItem(this.storageKey, JSON.stringify(items));
+    return items[index];
+  }
+
+  async delete(id: string): Promise<void> {
+    const items = await this.getAll();
+    const filtered = items.filter((i) => i.id !== id);
+    localStorage.setItem(this.storageKey, JSON.stringify(filtered));
+  }
+}

--- a/lib/lecturerService.ts
+++ b/lib/lecturerService.ts
@@ -1,0 +1,8 @@
+import { DataService } from './dataService';
+import { Lecturer } from './types';
+
+export class LocalStorageLecturerService extends DataService<Lecturer> {
+  protected storageKey = 'lecturers';
+}
+
+export const lecturerService = new LocalStorageLecturerService();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,71 @@
+export interface Lecturer {
+  id: string;
+  firstname: string;
+  lastname: string;
+  title?: string;
+  email?: string;
+  type: 'internal' | 'external';
+  yearlyHoursLimit?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface User {
+  id: string;
+  firstname: string;
+  lastname: string;
+  title?: string;
+  email: string;
+  role: 'admin' | 'user';
+  assignedStudyPrograms: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StudyProgram {
+  id: string;
+  name: string;
+  shortName: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Lecture {
+  id: string;
+  studyProgramId: string;
+  semester: number;
+  title: string;
+  hours: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Course {
+  id: string;
+  studyProgramId: string;
+  name: string;
+  startYear: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Assignment {
+  id: string;
+  lectureId: string;
+  courseId: string;
+  year: number;
+  quarter: 'Q1' | 'Q2' | 'Q3' | 'Q4';
+  lecturerId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ApplicationData {
+  lecturers: Lecturer[];
+  users: User[];
+  studyPrograms: StudyProgram[];
+  lectures: Lecture[];
+  courses: Course[];
+  assignments: Assignment[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2484,6 +2485,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- implement TypeScript interfaces and storage service
- add localStorage service for lecturers
- create pages to list and add lecturers
- update README with setup instructions

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f480b3810832dbd89273273a5ace3