### PR TITLE
Add MVP lecture planning features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DHBW Vorlesungsplanung
 
-Dieses Projekt stellt ein kleines MVP zur Verwaltung von Dozierenden dar. Die Anwendung basiert auf Next.js und speichert Daten im Browser `localStorage`.
+Dieses Projekt ist ein kleines MVP zur Planung von Vorlesungen an der DHBW. Alle Daten werden im Browser über `localStorage` gespeichert.
 
 ## Entwicklung starten
 
@@ -13,7 +13,11 @@ Die Anwendung läuft anschließend unter http://localhost:3000.
 
 ## Funktionen
 
-- Liste der Dozierenden unter `/dozierende`
-- Hinzufügen neuer Dozent\*innen über ein Formular
+- Dashboard mit Übersicht aller Daten
+- Verwaltung von Dozierenden unter `/dozierende`
+- Verwaltung von Studiengängen unter `/studiengaenge`
+- Verwaltung von Vorlesungen unter `/vorlesungen`
+- Verwaltung von Kursen unter `/kurse`
+- Einfache Vorlesungsplanung unter `/planung`
 
 Die Daten werden lokal im Browser gespeichert und können nach einem Reload wieder aufgerufen werden.

--- a/app/components/InitData.tsx
+++ b/app/components/InitData.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useEffect } from 'react';
+import { initData } from '@/lib/seed';
+
+export default function InitData() {
+  useEffect(() => {
+    initData();
+  }, []);
+  return null;
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -33,9 +33,27 @@ const Navbar = () => {
             </Link>
           </Button>
           <Button variant="ghost" size="sm" asChild>
-            <Link href="/test" className="flex items-center gap-1">
+            <Link href="/dozierende" className="flex items-center gap-1">
               <TestTube className="h-4 w-4" />
-              Test
+              Dozierende
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/vorlesungen" className="flex items-center gap-1">
+              <BookOpen className="h-4 w-4" />
+              Vorlesungen
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/kurse" className="flex items-center gap-1">
+              <BookOpen className="h-4 w-4" />
+              Kurse
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/planung" className="flex items-center gap-1">
+              <BookOpen className="h-4 w-4" />
+              Planung
             </Link>
           </Button>
           <Button variant="ghost" size="sm" asChild>
@@ -78,11 +96,38 @@ const Navbar = () => {
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <Link
-                  href="/test"
+                  href="/dozierende"
                   className="flex items-center gap-2 w-full"
                 >
                   <TestTube className="h-4 w-4" />
-                  Test
+                  Dozierende
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link
+                  href="/vorlesungen"
+                  className="flex items-center gap-2 w-full"
+                >
+                  <BookOpen className="h-4 w-4" />
+                  Vorlesungen
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link
+                  href="/kurse"
+                  className="flex items-center gap-2 w-full"
+                >
+                  <BookOpen className="h-4 w-4" />
+                  Kurse
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link
+                  href="/planung"
+                  className="flex items-center gap-2 w-full"
+                >
+                  <BookOpen className="h-4 w-4" />
+                  Planung
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>

--- a/app/kurse/neu/page.tsx
+++ b/app/kurse/neu/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
+import { courseService } from '@/lib/courseService';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { Course, StudyProgram } from '@/lib/types';
+
+export default function NewCoursePage() {
+  const router = useRouter();
+  const [programs, setPrograms] = useState<StudyProgram[]>([]);
+  const [form, setForm] = useState<Omit<Course, 'id' | 'createdAt' | 'updatedAt'>>({
+    studyProgramId: '',
+    name: '',
+    startYear: new Date().getFullYear(),
+  });
+
+  useEffect(() => {
+    studyProgramService.getAll().then(setPrograms);
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: name === 'startYear' ? Number(value) : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newCourse: Course = {
+      ...form,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await courseService.create(newCourse);
+    router.push('/kurse');
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Neuer Kurs</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Studiengang</label>
+          <select name="studyProgramId" className="border w-full p-2" value={form.studyProgramId} onChange={handleChange} required>
+            <option value="">Bitte wählen</option>
+            {programs.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.shortName}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Name</label>
+          <input name="name" className="border w-full p-2" value={form.name} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Startjahr</label>
+          <input type="number" name="startYear" className="border w-full p-2" value={form.startYear} onChange={handleChange} required />
+        </div>
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">Speichern</button>
+      </form>
+    </div>
+  );
+}

--- a/app/kurse/page.tsx
+++ b/app/kurse/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { courseService } from '@/lib/courseService';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { Course, StudyProgram } from '@/lib/types';
+
+export default function CoursesPage() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [programs, setPrograms] = useState<Record<string, StudyProgram>>({});
+
+  useEffect(() => {
+    courseService.getAll().then(setCourses);
+    studyProgramService.getAll().then((progs) => {
+      const map: Record<string, StudyProgram> = {};
+      progs.forEach((p) => (map[p.id] = p));
+      setPrograms(map);
+    });
+  }, []);
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Kurse</h1>
+        <Link href="/kurse/neu" className="text-blue-600 hover:underline">
+          + Hinzufügen
+        </Link>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-2 py-1 text-left">Name</th>
+            <th className="px-2 py-1 text-left">Studiengang</th>
+            <th className="px-2 py-1 text-left">Startjahr</th>
+          </tr>
+        </thead>
+        <tbody>
+          {courses.map((c) => (
+            <tr key={c.id} className="border-t">
+              <td className="px-2 py-1">{c.name}</td>
+              <td className="px-2 py-1">{programs[c.studyProgramId]?.shortName}</td>
+              <td className="px-2 py-1">{c.startYear}</td>
+            </tr>
+          ))}
+          {courses.length === 0 && (
+            <tr>
+              <td colSpan={3} className="p-4 text-center text-sm text-muted-foreground">
+                Keine Kurse vorhanden
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import Navbar from './components/Navbar';
+import InitData from './components/InitData';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -28,6 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
+        <InitData />
         <Navbar />
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,63 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { lecturerService } from '@/lib/lecturerService';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { courseService } from '@/lib/courseService';
+import { lectureService } from '@/lib/lectureService';
+import { assignmentService } from '@/lib/assignmentService';
+
 export default function HomePage() {
+  const [counts, setCounts] = useState({
+    lecturers: 0,
+    studyPrograms: 0,
+    courses: 0,
+    lectures: 0,
+    assignments: 0,
+  });
+
+  useEffect(() => {
+    Promise.all([
+      lecturerService.getAll(),
+      studyProgramService.getAll(),
+      courseService.getAll(),
+      lectureService.getAll(),
+      assignmentService.getAll(),
+    ]).then(([l, sp, c, le, a]) => {
+      setCounts({
+        lecturers: l.length,
+        studyPrograms: sp.length,
+        courses: c.length,
+        lectures: le.length,
+        assignments: a.length,
+      });
+    });
+  }, []);
+
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold">Home Page</h1>
-      <p className="text-xl font-extrabold text-red-500 mt-4">
-        Welcome to the home page!!!
-      </p>
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground">Dozierende</p>
+          <p className="text-2xl font-semibold">{counts.lecturers}</p>
+        </div>
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground">Studiengänge</p>
+          <p className="text-2xl font-semibold">{counts.studyPrograms}</p>
+        </div>
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground">Kurse</p>
+          <p className="text-2xl font-semibold">{counts.courses}</p>
+        </div>
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground">Vorlesungen</p>
+          <p className="text-2xl font-semibold">{counts.lectures}</p>
+        </div>
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground">Planungen</p>
+          <p className="text-2xl font-semibold">{counts.assignments}</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/planung/neu/page.tsx
+++ b/app/planung/neu/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
+import { assignmentService } from '@/lib/assignmentService';
+import { lectureService } from '@/lib/lectureService';
+import { courseService } from '@/lib/courseService';
+import { lecturerService } from '@/lib/lecturerService';
+import { Assignment, Lecture, Course, Lecturer } from '@/lib/types';
+
+export default function NewAssignmentPage() {
+  const router = useRouter();
+  const [lectures, setLectures] = useState<Lecture[]>([]);
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [lecturers, setLecturers] = useState<Lecturer[]>([]);
+
+  const [form, setForm] = useState<Omit<Assignment, 'id' | 'createdAt' | 'updatedAt'>>({
+    lectureId: '',
+    courseId: '',
+    year: new Date().getFullYear(),
+    quarter: 'Q1',
+    lecturerId: '',
+  });
+
+  useEffect(() => {
+    lectureService.getAll().then(setLectures);
+    courseService.getAll().then(setCourses);
+    lecturerService.getAll().then(setLecturers);
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: name === 'year' ? Number(value) : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newAssignment: Assignment = {
+      ...form,
+      lecturerId: form.lecturerId || undefined,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await assignmentService.create(newAssignment);
+    router.push('/planung');
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Neue Planung</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Vorlesung</label>
+          <select name="lectureId" className="border w-full p-2" value={form.lectureId} onChange={handleChange} required>
+            <option value="">Bitte wählen</option>
+            {lectures.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Kurs</label>
+          <select name="courseId" className="border w-full p-2" value={form.courseId} onChange={handleChange} required>
+            <option value="">Bitte wählen</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Jahr</label>
+          <input type="number" name="year" className="border w-full p-2" value={form.year} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Quartal</label>
+          <select name="quarter" className="border w-full p-2" value={form.quarter} onChange={handleChange} required>
+            <option value="Q1">Q1</option>
+            <option value="Q2">Q2</option>
+            <option value="Q3">Q3</option>
+            <option value="Q4">Q4</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Dozent*in (optional)</label>
+          <select name="lecturerId" className="border w-full p-2" value={form.lecturerId} onChange={handleChange}>
+            <option value="">-- unbesetzt --</option>
+            {lecturers.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.firstname} {l.lastname}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">Speichern</button>
+      </form>
+    </div>
+  );
+}

--- a/app/planung/page.tsx
+++ b/app/planung/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { assignmentService } from '@/lib/assignmentService';
+import { lectureService } from '@/lib/lectureService';
+import { courseService } from '@/lib/courseService';
+import { lecturerService } from '@/lib/lecturerService';
+import { Assignment, Lecture, Course, Lecturer } from '@/lib/types';
+
+export default function PlanningPage() {
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [lectures, setLectures] = useState<Record<string, Lecture>>({});
+  const [courses, setCourses] = useState<Record<string, Course>>({});
+  const [lecturers, setLecturers] = useState<Record<string, Lecturer>>({});
+
+  useEffect(() => {
+    assignmentService.getAll().then(setAssignments);
+    lectureService.getAll().then((ls) => {
+      const m: Record<string, Lecture> = {};
+      ls.forEach((l) => (m[l.id] = l));
+      setLectures(m);
+    });
+    courseService.getAll().then((cs) => {
+      const m: Record<string, Course> = {};
+      cs.forEach((c) => (m[c.id] = c));
+      setCourses(m);
+    });
+    lecturerService.getAll().then((ls) => {
+      const m: Record<string, Lecturer> = {};
+      ls.forEach((l) => (m[l.id] = l));
+      setLecturers(m);
+    });
+  }, []);
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Vorlesungsplanung</h1>
+        <Link href="/planung/neu" className="text-blue-600 hover:underline">
+          + Hinzufügen
+        </Link>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-2 py-1 text-left">Vorlesung</th>
+            <th className="px-2 py-1 text-left">Kurs</th>
+            <th className="px-2 py-1 text-left">Jahr</th>
+            <th className="px-2 py-1 text-left">Quartal</th>
+            <th className="px-2 py-1 text-left">Dozent*in</th>
+          </tr>
+        </thead>
+        <tbody>
+          {assignments.map((a) => (
+            <tr key={a.id} className="border-t">
+              <td className="px-2 py-1">{lectures[a.lectureId]?.title}</td>
+              <td className="px-2 py-1">{courses[a.courseId]?.name}</td>
+              <td className="px-2 py-1">{a.year}</td>
+              <td className="px-2 py-1">{a.quarter}</td>
+              <td className="px-2 py-1">
+                {a.lecturerId ? `${lecturers[a.lecturerId]?.firstname} ${lecturers[a.lecturerId]?.lastname}` : '-'}
+              </td>
+            </tr>
+          ))}
+          {assignments.length === 0 && (
+            <tr>
+              <td colSpan={5} className="p-4 text-center text-sm text-muted-foreground">
+                Keine Planungen vorhanden
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/studiengaenge/neu/page.tsx
+++ b/app/studiengaenge/neu/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { StudyProgram } from '@/lib/types';
+
+export default function NewStudyProgram() {
+  const router = useRouter();
+  const [form, setForm] = useState<Omit<StudyProgram, 'id' | 'createdAt' | 'updatedAt'>>({
+    name: '',
+    shortName: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newProgram: StudyProgram = {
+      ...form,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await studyProgramService.create(newProgram);
+    router.push('/studiengaenge');
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Neuer Studiengang</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Name</label>
+          <input name="name" className="border w-full p-2" value={form.name} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Kurzname</label>
+          <input name="shortName" className="border w-full p-2" value={form.shortName} onChange={handleChange} required />
+        </div>
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">Speichern</button>
+      </form>
+    </div>
+  );
+}

--- a/app/studiengaenge/page.tsx
+++ b/app/studiengaenge/page.tsx
@@ -1,65 +1,47 @@
-import React from 'react';
+'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { StudyProgram } from '@/lib/types';
 
-// Define a type for our study programs
-interface Studiengang {
-  id: string;
-  name: string;
-  description: string;
-}
+export default function StudyProgramsPage() {
+  const [programs, setPrograms] = useState<StudyProgram[]>([]);
 
-// Sample data for study programs
-const studiengaenge: Studiengang[] = [
-  {
-    id: 'informatik',
-    name: 'Informatik',
-    description: 'Vorlesungen und Details zum Studiengang Informatik',
-  },
-  {
-    id: 'wirtschaftsinformatik',
-    name: 'Wirtschaftsinformatik',
-    description:
-      'Vorlesungen und Details zum Studiengang Wirtschaftsinformatik',
-  },
-  {
-    id: 'bwl',
-    name: 'BWL',
-    description: 'Vorlesungen und Details zum Studiengang BWL',
-  },
-  {
-    id: 'maschinenbau',
-    name: 'Maschinenbau',
-    description:
-      'Vorlesungen und Details zum Studiengang Maschinenbau',
-  },
-];
+  useEffect(() => {
+    studyProgramService.getAll().then(setPrograms);
+  }, []);
 
-export default function Studiengaenge() {
   return (
     <div className="container mx-auto py-6">
-      <h1 className="text-2xl font-bold mb-6">Studiengänge</h1>
-
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {studiengaenge.map((studiengang) => (
-          <div
-            key={studiengang.id}
-            className="border rounded-lg p-4 hover:shadow-md transition-shadow"
-          >
-            <h2 className="text-lg font-semibold">
-              {studiengang.name}
-            </h2>
-            <p className="text-sm text-muted-foreground mt-2">
-              {studiengang.description}
-            </p>
-            <Link
-              href={`/studiengaenge/${studiengang.id}`}
-              className="mt-4 inline-block text-sm text-blue-600 hover:underline"
-            >
-              Details anzeigen
-            </Link>
-          </div>
-        ))}
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Studiengänge</h1>
+        <Link href="/studiengaenge/neu" className="text-blue-600 hover:underline">
+          + Hinzufügen
+        </Link>
       </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-2 py-1 text-left">Name</th>
+            <th className="px-2 py-1 text-left">Kurz</th>
+          </tr>
+        </thead>
+        <tbody>
+          {programs.map((p) => (
+            <tr key={p.id} className="border-t">
+              <td className="px-2 py-1">{p.name}</td>
+              <td className="px-2 py-1">{p.shortName}</td>
+            </tr>
+          ))}
+          {programs.length === 0 && (
+            <tr>
+              <td colSpan={2} className="p-4 text-center text-sm text-muted-foreground">
+                Keine Studiengänge vorhanden
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/app/vorlesungen/neu/page.tsx
+++ b/app/vorlesungen/neu/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
+import { lectureService } from '@/lib/lectureService';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { Lecture, StudyProgram } from '@/lib/types';
+
+export default function NewLecturePage() {
+  const router = useRouter();
+  const [programs, setPrograms] = useState<StudyProgram[]>([]);
+  const [form, setForm] = useState<Omit<Lecture, 'id' | 'createdAt' | 'updatedAt'>>({
+    studyProgramId: '',
+    semester: 1,
+    title: '',
+    hours: 1,
+  });
+
+  useEffect(() => {
+    studyProgramService.getAll().then(setPrograms);
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: name === 'semester' || name === 'hours' ? Number(value) : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newLecture: Lecture = {
+      ...form,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await lectureService.create(newLecture);
+    router.push('/vorlesungen');
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-2xl font-bold mb-4">Neue Vorlesung</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Studiengang</label>
+          <select name="studyProgramId" className="border w-full p-2" value={form.studyProgramId} onChange={handleChange} required>
+            <option value="">Bitte wählen</option>
+            {programs.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.shortName}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Semester</label>
+          <input type="number" name="semester" className="border w-full p-2" value={form.semester} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Titel</label>
+          <input name="title" className="border w-full p-2" value={form.title} onChange={handleChange} required />
+        </div>
+        <div>
+          <label className="block mb-1">Stunden</label>
+          <input type="number" name="hours" className="border w-full p-2" value={form.hours} onChange={handleChange} required />
+        </div>
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded">Speichern</button>
+      </form>
+    </div>
+  );
+}

--- a/app/vorlesungen/page.tsx
+++ b/app/vorlesungen/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { lectureService } from '@/lib/lectureService';
+import { studyProgramService } from '@/lib/studyProgramService';
+import { Lecture, StudyProgram } from '@/lib/types';
+
+export default function LecturesPage() {
+  const [lectures, setLectures] = useState<Lecture[]>([]);
+  const [programs, setPrograms] = useState<Record<string, StudyProgram>>({});
+
+  useEffect(() => {
+    lectureService.getAll().then(setLectures);
+    studyProgramService.getAll().then((progs) => {
+      const map: Record<string, StudyProgram> = {};
+      progs.forEach((p) => (map[p.id] = p));
+      setPrograms(map);
+    });
+  }, []);
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Vorlesungen</h1>
+        <Link href="/vorlesungen/neu" className="text-blue-600 hover:underline">
+          + Hinzufügen
+        </Link>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="px-2 py-1 text-left">Titel</th>
+            <th className="px-2 py-1 text-left">Studiengang</th>
+            <th className="px-2 py-1 text-left">Semester</th>
+            <th className="px-2 py-1 text-left">Stunden</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lectures.map((l) => (
+            <tr key={l.id} className="border-t">
+              <td className="px-2 py-1">{l.title}</td>
+              <td className="px-2 py-1">{programs[l.studyProgramId]?.shortName}</td>
+              <td className="px-2 py-1">{l.semester}</td>
+              <td className="px-2 py-1">{l.hours}</td>
+            </tr>
+          ))}
+          {lectures.length === 0 && (
+            <tr>
+              <td colSpan={4} className="p-4 text-center text-sm text-muted-foreground">
+                Keine Vorlesungen vorhanden
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/assignmentService.ts
+++ b/lib/assignmentService.ts
@@ -1,0 +1,8 @@
+import { DataService } from './dataService';
+import { Assignment } from './types';
+
+export class LocalStorageAssignmentService extends DataService<Assignment> {
+  protected storageKey = 'assignments';
+}
+
+export const assignmentService = new LocalStorageAssignmentService();

--- a/lib/courseService.ts
+++ b/lib/courseService.ts
@@ -1,0 +1,8 @@
+import { DataService } from './dataService';
+import { Course } from './types';
+
+export class LocalStorageCourseService extends DataService<Course> {
+  protected storageKey = 'courses';
+}
+
+export const courseService = new LocalStorageCourseService();

--- a/lib/lectureService.ts
+++ b/lib/lectureService.ts
@@ -1,0 +1,8 @@
+import { DataService } from './dataService';
+import { Lecture } from './types';
+
+export class LocalStorageLectureService extends DataService<Lecture> {
+  protected storageKey = 'lectures';
+}
+
+export const lectureService = new LocalStorageLectureService();

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,0 +1,66 @@
+import { ApplicationData, Lecturer, StudyProgram, Lecture, Course, Assignment } from './types';
+import { lecturerService } from './lecturerService';
+import { studyProgramService } from './studyProgramService';
+import { lectureService } from './lectureService';
+import { courseService } from './courseService';
+import { assignmentService } from './assignmentService';
+
+const seedData: ApplicationData = {
+  lecturers: [
+    {
+      id: '1',
+      firstname: 'Max',
+      lastname: 'Mustermann',
+      title: 'Dr.',
+      email: 'max@example.com',
+      type: 'external',
+      yearlyHoursLimit: 240,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ],
+  users: [],
+  studyPrograms: [
+    { id: '1', name: 'Betriebswirtschaftslehre', shortName: 'BWL', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    { id: '2', name: 'Informatik', shortName: 'INF', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  ],
+  lectures: [
+    {
+      id: '1',
+      studyProgramId: '1',
+      semester: 1,
+      title: 'Marketing Grundlagen',
+      hours: 20,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: '2',
+      studyProgramId: '1',
+      semester: 1,
+      title: 'Controlling Basics',
+      hours: 16,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ],
+  courses: [
+    { id: '1', studyProgramId: '1', name: 'BWL Kurs 2024', startYear: 2024, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    { id: '2', studyProgramId: '1', name: 'BWL Kurs 2023', startYear: 2023, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  ],
+  assignments: [
+    { id: '1', lectureId: '1', courseId: '1', year: 2024, quarter: 'Q2', lecturerId: '1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  ],
+};
+
+export async function initData() {
+  if (typeof window === 'undefined') return;
+  const lecturers = await lecturerService.getAll();
+  if (lecturers.length === 0) {
+    localStorage.setItem('lecturers', JSON.stringify(seedData.lecturers));
+    localStorage.setItem('studyPrograms', JSON.stringify(seedData.studyPrograms));
+    localStorage.setItem('lectures', JSON.stringify(seedData.lectures));
+    localStorage.setItem('courses', JSON.stringify(seedData.courses));
+    localStorage.setItem('assignments', JSON.stringify(seedData.assignments));
+  }
+}

--- a/lib/studyProgramService.ts
+++ b/lib/studyProgramService.ts
@@ -1,0 +1,8 @@
+import { DataService } from './dataService';
+import { StudyProgram } from './types';
+
+export class LocalStorageStudyProgramService extends DataService<StudyProgram> {
+  protected storageKey = 'studyPrograms';
+}
+
+export const studyProgramService = new LocalStorageStudyProgramService();


### PR DESCRIPTION
## Summary
- seed localStorage with demo data on first load
- add dashboard overview
- implement management pages for study programs, courses, lectures and planning
- extend navigation for new pages

## Testing
- `npm install`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a3db368832d8e668ef2b0e32a69