### PR TITLE
Implement lecturer modal

### DIFF
--- a/app/lecturers/page.tsx
+++ b/app/lecturers/page.tsx
@@ -1,11 +1,16 @@
+import { AddLecturerDialog } from '@/components/lecturers/add-lecturer-dialog'
+
 export default function LecturersPage() {
   return (
-    <div className="container mx-auto p-6">
-      <h1 className="text-3xl font-bold mb-6">👥 Dozierende</h1>
+    <div className="container mx-auto p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">👥 Dozierende</h1>
+        <AddLecturerDialog />
+      </div>
       <p className="text-muted-foreground">
-        Hier wird die Dozierenden-Verwaltung implementiert (aus
-        Wireframe #4).
+        Hier wird die Dozierenden-Verwaltung implementiert (aus Wireframe
+        #4). Der Dialog zum Hinzufügen entspricht Wireframe #5.
       </p>
     </div>
-  );
+  )
 }

--- a/components/lecturers/add-lecturer-dialog.tsx
+++ b/components/lecturers/add-lecturer-dialog.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+
+export function AddLecturerDialog() {
+  const [open, setOpen] = useState(false)
+  const [category, setCategory] = useState<"internal" | "external">("external")
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="default">➕ Hinzufügen</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Neue*n Dozent*in hinzufügen</DialogTitle>
+        </DialogHeader>
+        <form className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="title">Titel (optional)</Label>
+              <select
+                id="title"
+                className="mt-1 h-10 w-full rounded-md border px-3 py-2 text-sm"
+                defaultValue=""
+              >
+                <option value="">--</option>
+                <option value="Prof.">Prof.</option>
+                <option value="Prof. Dr.">Prof. Dr.</option>
+                <option value="Dr.">Dr.</option>
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="firstname">Vorname*</Label>
+              <Input id="firstname" placeholder="Anna" />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="lastname">Nachname*</Label>
+            <Input id="lastname" placeholder="Schmidt" />
+          </div>
+
+          <div>
+            <Label htmlFor="email">E-Mail</Label>
+            <Input id="email" type="email" placeholder="schmidt@dhbw.de" />
+          </div>
+
+          <div className="space-y-2">
+            <p className="font-medium">Kategorie</p>
+            <RadioGroup
+              value={category}
+              onValueChange={(val) => setCategory(val as "internal" | "external")}
+              className="flex gap-4"
+            >
+              <label className="flex items-center gap-2 text-sm">
+                <RadioGroupItem value="internal" />
+                Intern (DHBW Mitarbeiter*in)
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <RadioGroupItem value="external" />
+                Extern (Lehrbeauftragte*r)
+              </label>
+            </RadioGroup>
+          </div>
+
+          {category === "external" && (
+            <div>
+              <Label htmlFor="limit">Stundenkapazität (Jahresgrenze)</Label>
+              <div className="flex items-center gap-2">
+                <Input id="limit" type="number" placeholder="240" className="w-32" />
+                <span>h</span>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <Label htmlFor="expertise">Fachgebiete (optional)</Label>
+            <Input
+              id="expertise"
+              placeholder="Marketing, BWL Grundlagen, Controlling"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="notes">Notizen (optional)</Label>
+            <Textarea id="notes" placeholder="Expertise in digitalem Marketing..." />
+          </div>
+        </form>
+        <DialogFooter className="mt-4">
+          <Button>💾 Speichern</Button>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            ❌ Abbrechen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogClose = DialogPrimitive.Close
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 grid w-full max-w-lg gap-4 rounded-lg border bg-background p-6 shadow-lg left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-90 data-[state=closed]:zoom-out-90",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <X className="size-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, type = "text", ...props }, ref) => (
+  <input
+    type={type}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<
+  React.ElementRef<"label">,
+  React.ComponentPropsWithoutRef<"label">
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = "Label"
+
+export { Label }

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { cn } from "@/lib/utils"
+
+const RadioGroup = RadioGroupPrimitive.Root
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "h-4 w-4 rounded-full border border-input text-primary ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <div className="h-2 w-2 rounded-full bg-current" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+))
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  />
+))
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
## Summary
- add UI primitives (dialog, input, label, textarea, radio group)
- add `AddLecturerDialog` component implementing wireframe #5
- integrate modal on lecturers page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc16ddb8832d8649df77623b8db5