### PR TITLE
Improve navigation

### DIFF
--- a/app/lecturers/[id]/edit/page.tsx
+++ b/app/lecturers/[id]/edit/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { lecturers } from '../../data';
+import { notFound } from 'next/navigation';
+
+export default function LecturerEditPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const lecturer = lecturers.find((l) => l.id === params.id);
+
+  if (!lecturer) {
+    notFound();
+  }
+
+  const fullName = `${lecturer?.title ? lecturer.title + ' ' : ''}${lecturer?.name}`;
+
+  return (
+    <div className="container mx-auto p-6 space-y-4">
+      <Link href={`/lecturers/${params.id}`} className="text-sm text-blue-600 underline">
+        ← Zurück
+      </Link>
+      <h1 className="text-2xl font-bold">{fullName} bearbeiten</h1>
+      <p className="text-muted-foreground">
+        Diese Seite ist ein Platzhalter f\u00fcr das Bearbeitungsformular.
+      </p>
+    </div>
+  );
+}

--- a/app/lecturers/[id]/page.tsx
+++ b/app/lecturers/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { lecturers } from '../data';
+
+export default function LecturerDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const lecturer = lecturers.find((l) => l.id === params.id);
+
+  if (!lecturer) {
+    notFound();
+  }
+
+  const fullName = `${lecturer?.title ? lecturer.title + ' ' : ''}${lecturer?.name}`;
+
+  return (
+    <div className="container mx-auto p-6 space-y-4">
+      <Link href="/lecturers" className="text-sm text-blue-600 underline">
+        ← Zurück
+      </Link>
+      <h1 className="text-3xl font-bold">{fullName}</h1>
+      <p className="text-sm">📧 {lecturer?.email}</p>
+      <p className="text-sm">📞 {lecturer?.phone}</p>
+      <p className="text-sm">
+        Typ: {lecturer?.type === 'internal' ? 'Intern' : 'Extern'}
+      </p>
+    </div>
+  );
+}

--- a/app/lecturers/data.ts
+++ b/app/lecturers/data.ts
@@ -1,0 +1,56 @@
+export interface LecturerOverview {
+  id: string;
+  name: string;
+  title?: string;
+  email: string;
+  phone: string;
+  type: 'internal' | 'external';
+  yearlyHours: number;
+  yearlyLimit?: number;
+  expertise: string[];
+  quarters: Record<'Q1' | 'Q2' | 'Q3' | 'Q4', number>;
+  warning?: string;
+  status?: 'ok' | 'warning';
+}
+
+export const lecturers: LecturerOverview[] = [
+  {
+    id: '1',
+    name: 'Anna Schmidt',
+    title: 'Prof. Dr.',
+    email: 'schmidt@dhbw.de',
+    phone: '+49 721 123-456',
+    type: 'internal',
+    yearlyHours: 85,
+    expertise: ['Marketing', 'BWL Grundlagen'],
+    quarters: { Q1: 25, Q2: 40, Q3: 20, Q4: 0 },
+    status: 'ok',
+  },
+  {
+    id: '2',
+    name: 'Hans M\u00fcller',
+    title: 'Dr.',
+    email: 'mueller@extern.de',
+    phone: '+49 711 987-654',
+    type: 'external',
+    yearlyHours: 215,
+    yearlyLimit: 240,
+    expertise: ['Informatik', 'Programmierung'],
+    quarters: { Q1: 80, Q2: 75, Q3: 60, Q4: 0 },
+    warning: 'Nur noch 25h Kapazit\u00e4t verf\u00fcgbar!',
+    status: 'warning',
+  },
+  {
+    id: '3',
+    name: 'Sarah Weber',
+    title: 'M.',
+    email: 'weber@beratung.de',
+    phone: '+49 621 456-789',
+    type: 'external',
+    yearlyHours: 160,
+    yearlyLimit: 240,
+    expertise: ['Projektmanagement', 'Consulting'],
+    quarters: { Q1: 40, Q2: 60, Q3: 60, Q4: 0 },
+    status: 'ok',
+  },
+];

--- a/app/lecturers/new/page.tsx
+++ b/app/lecturers/new/page.tsx
@@ -1,0 +1,10 @@
+export default function NewLecturerPage() {
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Neuen Dozenten anlegen</h1>
+      <p className="text-muted-foreground">
+        Diese Seite dient als Platzhalter f\u00fcr das Formular zur Anlage neuer Dozierender.
+      </p>
+    </div>
+  );
+}

--- a/app/lecturers/page.tsx
+++ b/app/lecturers/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from 'react';
+import Link from 'next/link';
 import {
   Card,
   CardContent,
@@ -9,63 +10,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { ProgressBar, BlockProgressBar } from '@/components/ui/progress';
 import type { Quarter } from '@/lib/types';
+import { lecturers, type LecturerOverview } from './data';
 
-interface LecturerOverview {
-  id: string;
-  name: string;
-  title?: string;
-  email: string;
-  phone: string;
-  type: 'internal' | 'external';
-  yearlyHours: number;
-  yearlyLimit?: number;
-  expertise: string[];
-  quarters: Record<Quarter, number>;
-  warning?: string;
-  status?: 'ok' | 'warning';
-}
-
-const lecturers: LecturerOverview[] = [
-  {
-    id: '1',
-    name: 'Anna Schmidt',
-    title: 'Prof. Dr.',
-    email: 'schmidt@dhbw.de',
-    phone: '+49 721 123-456',
-    type: 'internal',
-    yearlyHours: 85,
-    expertise: ['Marketing', 'BWL Grundlagen'],
-    quarters: { Q1: 25, Q2: 40, Q3: 20, Q4: 0 },
-    status: 'ok',
-  },
-  {
-    id: '2',
-    name: 'Hans Müller',
-    title: 'Dr.',
-    email: 'mueller@extern.de',
-    phone: '+49 711 987-654',
-    type: 'external',
-    yearlyHours: 215,
-    yearlyLimit: 240,
-    expertise: ['Informatik', 'Programmierung'],
-    quarters: { Q1: 80, Q2: 75, Q3: 60, Q4: 0 },
-    warning: 'Nur noch 25h Kapazität verfügbar!',
-    status: 'warning',
-  },
-  {
-    id: '3',
-    name: 'Sarah Weber',
-    title: 'M.',
-    email: 'weber@beratung.de',
-    phone: '+49 621 456-789',
-    type: 'external',
-    yearlyHours: 160,
-    yearlyLimit: 240,
-    expertise: ['Projektmanagement', 'Consulting'],
-    quarters: { Q1: 40, Q2: 60, Q3: 60, Q4: 0 },
-    status: 'ok',
-  },
-];
 
 export default function LecturersPage() {
   const [filter, setFilter] = useState<'all' | 'internal' | 'external'>('all');
@@ -84,7 +30,9 @@ export default function LecturersPage() {
     <div className="container mx-auto p-6 space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">👥 Dozierende</h1>
-        <Button size="sm">➕ Hinzufügen</Button>
+        <Button size="sm" asChild>
+          <Link href="/lecturers/new">➕ Hinzufügen</Link>
+        </Button>
       </div>
 
       {/* Filter & Search */}
@@ -182,14 +130,14 @@ export default function LecturersPage() {
                   </div>
                 )}
                 <div className="pt-2 flex flex-wrap gap-2">
-                  <Button variant="outline" size="sm">
-                    ✏️ Bearbeiten
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/lecturers/${lec.id}/edit`}>✏️ Bearbeiten</Link>
                   </Button>
-                  <Button variant="outline" size="sm">
-                    📊 Details
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/lecturers/${lec.id}`}>📊 Details</Link>
                   </Button>
-                  <Button variant="outline" size="sm">
-                    📅 Planung anzeigen
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/planning">📅 Planung anzeigen</Link>
                   </Button>
                 </div>
               </CardContent>

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -1,11 +1,53 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { StudyProgramsCard } from '@/components/dashboard/study-programs-card';
+import type { StudyProgramStatus } from '@/lib/types';
+
 export default function PlanningPage() {
+  const router = useRouter();
+  const [programs, setPrograms] = useState<StudyProgramStatus[]>([]);
+
+  useEffect(() => {
+    // Mock data analog zum Dashboard
+    const mock: StudyProgramStatus[] = [
+      {
+        id: 'bwl',
+        name: 'BWL',
+        shortName: 'BWL',
+        quarters: {
+          Q1: { status: 'complete', percentage: 100, totalLectures: 12, assignedLectures: 12 },
+          Q2: { status: 'partial', percentage: 85, totalLectures: 10, assignedLectures: 8 },
+          Q3: { status: 'empty', percentage: 0, totalLectures: 8, assignedLectures: 0 },
+          Q4: { status: 'empty', percentage: 0, totalLectures: 6, assignedLectures: 0 },
+        },
+        courses: ['BWL 2024', 'BWL 2023'],
+      },
+      {
+        id: 'informatik',
+        name: 'Informatik',
+        shortName: 'INF',
+        quarters: {
+          Q1: { status: 'complete', percentage: 100, totalLectures: 15, assignedLectures: 15 },
+          Q2: { status: 'complete', percentage: 100, totalLectures: 12, assignedLectures: 12 },
+          Q3: { status: 'partial', percentage: 40, totalLectures: 10, assignedLectures: 4 },
+          Q4: { status: 'empty', percentage: 0, totalLectures: 8, assignedLectures: 0 },
+        },
+        courses: ['INF 2024', 'INF 2023'],
+      },
+    ];
+    setPrograms(mock);
+  }, []);
+
+  const handlePlanClick = (id: string) => {
+    router.push(`/planning/${id}`);
+  };
+
   return (
-    <div className="container mx-auto p-6">
-      <h1 className="text-3xl font-bold mb-6">📅 Quartalsplanung</h1>
-      <p className="text-muted-foreground">
-        Hier wird die Quartalsplanung implementiert (aus Wireframe
-        #2).
-      </p>
+    <div className="container mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-bold">📅 Quartalsplanung</h1>
+      <StudyProgramsCard programs={programs} onPlanClick={handlePlanClick} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add dataset for lecturer overview and import in index page
- link lecturer actions to dedicated pages
- add placeholder pages for new, edit and detail views
- flesh out planning overview with study program list

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6863be0d8f70832dab9a97dffc019e32